### PR TITLE
Add "plain" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_enum_derive"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Terry Raimondo <terry.raimondo@gmail.com>"]
 description = "Simple Enum derive for [Postgres only] Varchar fields"
 license = "MIT"
@@ -10,8 +10,13 @@ repository = "https://github.com/terry90/diesel-enum-derive"
 [lib]
 proc-macro = true
 
+[features]
+default = ["heck"]
+heck = ["dep:heck"]
+plain = []
+
 [dependencies]
 quote = "1.0.18"
 syn = { version = "1.0.96", features = ["derive"] }
 proc-macro2 = "1.0.39"
-heck = "0.4.0"
+heck = { optional = true, version = "0.4.0" }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Please note that this crate is aimed to be simple and stick to a simple usage, n
 
 For a more advanced usage, see this crate: [adwhit/diesel-derive-enum](https://github.com/adwhit/diesel-derive-enum)
 
+## Features
+
+This crate has two features:
+
+* `heck` uses `heck::ToSnakeCase` to transform enum values. This feature is enabled by default.
+* `plain` keep enum values, use with `default-features = false`.
+
 ## Usage
 
 ```rust
@@ -25,5 +32,5 @@ The version compatibility is specified in the following table:
 
 | Diesel version | Diesel-enum-derive version |
 | -------------- | -------------------------- |
-| <=1.4.8 | 0.1.4 |
-| \>=2.0.0 | 1.0.0 |
+| <=1.4.8        | 0.1.4                      |
+| \>=2.0.0       | 1.0.0                      |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ fn impl_diesel_enum(name: Ident, variants: &[Variant]) -> TokenStream {
     let name_iter2 = std::iter::repeat(&name);
     let name_iter3 = std::iter::repeat(&name);
 
-    let scope = Ident::new(&format!("diesel_enum_{}", name), Span::call_site());
+    let scope = Ident::new(&format!("diesel_enum_{name}"), Span::call_site());
 
     let keys = &variants.iter().map(|v| v.key.clone()).collect::<Vec<_>>();
     let values = &variants.iter().map(|v| v.value.clone()).collect::<Vec<_>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,13 @@ extern crate proc_macro;
 extern crate syn;
 #[macro_use]
 extern crate quote;
-extern crate heck;
 extern crate proc_macro2;
 
+#[cfg(feature = "heck")]
+extern crate heck;
+#[cfg(feature = "heck")]
 use heck::ToSnakeCase;
+
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::Ident;
@@ -25,9 +28,13 @@ pub fn diesel_enum(input: TokenStream) -> TokenStream {
     if let syn::Data::Enum(enum_data) = ast.data {
         let mut variants = Vec::new();
         for variant in enum_data.variants.into_iter() {
+            #[cfg(feature = "heck")]
+            let value = variant.ident.to_string().to_snake_case();
+            #[cfg(feature = "plain")]
+            let value = variant.ident.to_string();
             variants.push(Variant {
                 key: variant.ident.clone(),
-                value: variant.ident.to_string().to_snake_case(),
+                value,
             });
         }
 


### PR DESCRIPTION
Added a `plain` feature to allow keeping enum variants without using `to_snake_case`.

The default behavior is kept under a `heck` feature.